### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -4,6 +4,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/zijipia/Ziji-bot-discord/security/code-scanning/2](https://github.com/zijipia/Ziji-bot-discord/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Since the workflow involves checking and formatting code, it primarily needs `contents: read` for reading repository contents and `contents: write` for pushing formatting changes. No other permissions are necessary based on the provided workflow.

The `permissions` block should be added at the root level, just below the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
