### PR TITLE
Sửa quyền Button

### DIFF
--- a/functions/button/B_Cfs_Reject.js
+++ b/functions/button/B_Cfs_Reject.js
@@ -15,7 +15,7 @@ module.exports.data = {
 
 module.exports.execute = async ({ interaction, lang }) => {
 	const member = await interaction.guild.members.fetch(interaction.user);
-	if (member.permissions.has(PermissionsBitField.Flags.ManageGuild)) {
+	if (!member.permissions.has(PermissionsBitField.Flags.ManageGuild)) {
 		return interaction.reply({
 			content: lang.until.noPermission,
 			flags: MessageFlags.Ephemeral,


### PR DESCRIPTION
Sửa lỗi logic trên code là kiểm tra quyền ngược, nếu có quyền thì từ chối  Bây giờ logic quyền confession đã hoạt động đúng - chỉ những người có quyền ManageGuild mới có thể setup, enable và kiểm duyệt confession!

